### PR TITLE
Enable access to all frames

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
 
   "content_scripts": [
     {
+      "all_frames": true,
       "matches": ["<all_urls>"],
       "js": ["content/main.js"]
     }


### PR DESCRIPTION
Now the extension will be able to detect video in other frames.
Now it works in Google Drive videos, but there is an issue still as stated in #6:
The audio is not detected.
