### PR TITLE
Fix for media elements within nested iFrame elements

### DIFF
--- a/content/main.js
+++ b/content/main.js
@@ -464,10 +464,21 @@ const inspectElement = async (element) => {
 }
 
 const inspectAllMediaElements = () => {
-  const elements = [
-    ...document.getElementsByTagName('video'),
-    ...document.getElementsByTagName('audio'),
-  ];
+  function getElementsRecursive(rootEl) {
+    // Get all media elements within this root element context
+    const elementsWithinRoot = [
+      ...rootEl.getElementsByTagName('video'),
+      ...rootEl.getElementsByTagName('audio'),
+    ];
+    // Recursively locate media elements within iframes on the page
+    const elementsInNestedFrames = Array.from(rootEl.getElementsByTagName('iframe')).reduce((acc, frame) => {
+      return [...acc, ...getElementsRecursive(frame.contentDocument)]
+    }, []);
+    // Return all elements with duplicates removed
+    return [...new Set([...elementsWithinRoot, ...elementsInNestedFrames])];
+  }
+
+  const elements = getElementsRecursive(document);
 
   if (elements.length === 0) {
     debug('No source found');

--- a/content/main.js
+++ b/content/main.js
@@ -465,6 +465,8 @@ const inspectElement = async (element) => {
 
 const inspectAllMediaElements = () => {
   function getElementsRecursive(rootEl) {
+    if (!rootEl) return [];
+    
     // Get all media elements within this root element context
     const elementsWithinRoot = [
       ...rootEl.getElementsByTagName('video'),


### PR DESCRIPTION
Thanks for creating this extension! I've found it very helpful for reviewing some of my class material before exams :)

I made my own edit to enable usage on sites where media elements are nested within iframe elements. My university uses embedded players, which was originally not recognized by your extension. 

The changes in this PR allow the extension to recursively detect media elements within nested iframes on the page.

Does this sound like a good addition to the extension?