### PR TITLE
Search for media elements when document.readyState is "interactive" (fixes #29)

### DIFF
--- a/src/pages/content/lib/inspectMediaElements.ts
+++ b/src/pages/content/lib/inspectMediaElements.ts
@@ -55,7 +55,7 @@ export default function inspectMediaElements(callback : Function) {
   // A list of all elements we have already discovered
   const inspectedElements : MediaElement[] = [];
 
-  if (document.readyState === "complete") {
+  if (document.readyState === "interactive" || document.readyState === "complete") {
     // Search current elements
     searchElements(inspectedElements, callback);
   } else {


### PR DESCRIPTION
This PR should fix issue #29. `document.readyState` [can be "interactive" when the `DOMContentLoaded` event is fired](https://stackoverflow.com/a/13346803/4306257), so it needs to be checked against this value in the shortcut if branch as well.