### PR TITLE
Fixed video sizing for videos larger than the screen

### DIFF
--- a/player/main.css
+++ b/player/main.css
@@ -74,3 +74,8 @@ a {
 .fileContainer [type=file] {
   display: none;
 }
+
+.player, #player {
+  height: 100vh;
+  width: 100%;
+}


### PR DESCRIPTION
This PR fixes video sizing in the local files player when the video's resolution is larger than the screen (or a window) with the player.

**Before**
![image](https://user-images.githubusercontent.com/15214494/108599386-20a3f400-7391-11eb-90c7-b47a789ca932.png)

**After**
![image](https://user-images.githubusercontent.com/15214494/108599406-35808780-7391-11eb-8981-ad392da49202.png)
