### PR TITLE
Fix speed not changing on Microsoft SharePoint

### DIFF
--- a/example_page/ratechange.html
+++ b/example_page/ratechange.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Skip Silence Sample With Buffering</title>
+
+    <style>
+      canvas {
+        width: 500px;
+        height: 100px;
+        background: #002d3c;
+        float: left;
+      }
+    </style>
+  </head>
+  <body>
+    <video src="./test.mp4" controls></video>
+    <p>This is an example webpage to develop and test Skip Silence with a video that blocks changes to the playback rate while its buffering.</p>
+    <p>Video used: https://www.youtube.com/watch?v=xWsD6a3KsAI</p>
+
+    <script>
+      /** 
+       * Simulate a video buffering every 4 seconds and blocking changes to the playback rate while doing so.
+       * This kind of behavior can be observed on websites like Microsoft SharePoint.
+       */
+      const bufferInterval = 4000;
+      const video = document.querySelector('video');
+      let canPlay = false;
+      function onVideoRateChange() {
+        // Don't allow playing the video while buffering
+        const rate = canPlay ? 1 : 0;
+        video.playbackRate !== rate && (video.playbackRate = video.defaultPlaybackRate = rate);
+      }
+      video.onratechange = () => { onVideoRateChange() }
+      // Simulate the video buffering every once in a while
+      setInterval(() => {
+        canPlay = !canPlay;
+        onVideoRateChange();
+      }, bufferInterval);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
SharePoint has an event listener for the `ratechange` event that forcibly sets the rate to 1 or 0 depending on some internal variables, overriding any changes SkipSilence makes. We can fix this by temporarily removing the event listener when Skip Silence fails to change the rate and the new rate was not 0. When the new rate is set to 0 by SharePoint, it's probably for a good reason and SkipSilence should not tamper with it.

This fix should work on other sites that block changing the playback rate in a similar way, but it has only been tested on SharePoint. To this end, add a new sample page, `example_page/ratechange.html`, for testing with an emulated version of the SharePoint behaviour.