### PR TITLE
Fix playback speed issue on certain detected media

### DIFF
--- a/src/contents/lib/SpeedController.ts
+++ b/src/contents/lib/SpeedController.ts
@@ -1,4 +1,5 @@
 import debugging from "debug"
+import inspectMediaElements from "./inspectMediaElements"
 
 import type { MediaElement } from "../../shared/types"
 
@@ -100,18 +101,7 @@ export default class SpeedController {
   }
 
   setPlaybackRate(rate: number) {
-    this.elements = [
-      ...document.querySelectorAll("video, audio")
-    ] as MediaElement[]
-    debug(
-      "Setting playback rate to",
-      rate,
-      "on",
-      this.elements.length,
-      "elements"
-    )
-
-    this.elements.forEach((element) => {
+    inspectMediaElements((element: MediaElement) => {
       this.setPlaybackRateForElement(rate, element)
     })
   }

--- a/src/contents/lib/SpeedController.ts
+++ b/src/contents/lib/SpeedController.ts
@@ -17,6 +17,12 @@ export default class SpeedController {
 
   elements: MediaElement[] = []
 
+  constructor() {
+    inspectMediaElements((element: MediaElement) => {
+      this.elements.push(element)
+    })
+  }
+
   /**
    * Fixes issues changing the playback rate by temporarily blocking `ratechange` event listeners.
    */
@@ -101,7 +107,7 @@ export default class SpeedController {
   }
 
   setPlaybackRate(rate: number) {
-    inspectMediaElements((element: MediaElement) => {
+    this.elements.forEach((element) => {
       this.setPlaybackRateForElement(rate, element)
     })
   }


### PR DESCRIPTION
Fixes #136 where certain media types would not be detected by 
`document.querySelectorAll("video, audio")`